### PR TITLE
feat(workflow): Add workflow for generating bill-of-materials

### DIFF
--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -30,7 +30,6 @@ jobs:
               run: |
                   TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'deps')
                   ( go mod tidy > /dev/null 2>&1; go list -m -json all | go-licence-detector -depsTemplate=../.dependencies/templates/dependencies.csv.tmpl -depsOut="${TMP_DIR}"/"${MODULE}"-dependencies.txt  -overrides=../.dependencies/overrides/overrides.json )
-                  done
                   cat "$TMP_DIR"/*.txt | sort | uniq > dependencies-and-licenses-go.txt
                   echo
                   echo "👍 done. written results to ./dependencies-and-licenses-go.txt"


### PR DESCRIPTION
This commit adds a workflow for generating the bill of materials for
`monaco` and its dependencies (including the documentation). The
workflow needs to be started manually for now. At a later point in time,
we can run it for every release. But for now: let's keep it simple.

The approach is "borrowed" from `keptn/keptn` :)

fixes #466